### PR TITLE
Update moderncvbodyi.sty

### DIFF
--- a/moderncvbodyi.sty
+++ b/moderncvbodyi.sty
@@ -108,8 +108,8 @@
     {\bfseries#3}%
     \ifthenelse{\equal{#4}{}}{}{, {\slshape#4}}%
     \ifthenelse{\equal{#5}{}}{}{, #5}%
-    \ifthenelse{\equal{#6}{}}{}{, #6}%
-    .\strut%
+    \ifthenelse{\equal{#6}{}}{}{, #6.}%
+    \strut%
     \ifx&#7&%
     \else{\newline{}\begin{minipage}[t]{\linewidth}\small#7\end{minipage}}\fi}}
 


### PR DESCRIPTION
avoids a single dot to be placed if you put an empty cventry section like:

\cventry{}{}{}{}{}{
...
}
