### PR TITLE
Corrected bug in hypersetup

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -128,9 +128,13 @@
     bookmarksopen = true,
     bookmarksdepth= 2,% to show sections and subsections
     pdfauthor     = {\@firstname{}~\@lastname{}},
-    pdftitle      = {\@firstname{}~\@lastname{}\notblank{\@title}{ -- \@title}{}},
     pdfsubject    = {Resum\'{e} of \@firstname{}~\@lastname{}},
-    pdfkeywords   = {\@firstname{}~\@lastname{}, curriculum vit\ae{}, resum\'{e}}}}
+    pdfkeywords   = {\@firstname{}~\@lastname{}, curriculum vit\ae{}, resum\'{e}, CV}}}%
+
+\AtBeginDocument{%
+	\ifthenelse{\equal{\@title}{}}%
+		{\hypersetup{ pdftitle = {\@firstname{}~\@lastname{}}}}%
+		{\hypersetup{ pdftitle = {\@firstname{}~\@lastname{} -- \@title}}}}%
 
 % graphics
 \RequirePackage{graphicx}

--- a/moderncv.cls
+++ b/moderncv.cls
@@ -191,6 +191,7 @@
 % compatibility package with older versions of moderncv
 \RequirePackageWithOptions{moderncvcompatibility}
 
+\RequirePackage{l3regex}
 
 %-------------------------------------------------------------------------------
 %                class definition
@@ -247,7 +248,11 @@
 % usage: \phone[<optional type>]{<number>}
 % where <optional type> should be either "fixed" (default), "mobile" or "fax
 \collectionnew{phones}
-\newcommand*{\phone}[2][fixed]{\collectionadd[#1]{phones}{#2}}
+\NewDocumentCommand{\phone}{O{fixed}m}{%
+  \ifthenelse{\equal{#1}{fax}}%
+    {\collectionadd[#1]{phones}{#2}}
+    {\collectionadd[#1]{phones}{\protect\tellink{#2}}}
+    }
 
 % adds a social link to one's personal information (optional)
 % usage: \social[<optional type>][<optional url>]{<account name>}
@@ -501,6 +506,22 @@
   \ifthenelse{\equal{#1}{}}%
     {\href{mailto:#2}{#2}}%
     {\href{mailto:#2}{#1}}}
+    
+% makes a tel hyperlink
+% usage: \tellink[optional text]{link}
+\newcommand*{\tellink}[2][]{%
+  \ifthenelse{\equal{#1}{}}%
+    {\expandafter\onlynumberslink\expandafter{#2}{#2}}%
+    {\expandafter\onlynumberslink\expandafter{#2}{#1}}}
+
+\ExplSyntaxOn
+\tl_new:N \l_onlynumberslink_tl
+\cs_new:Npn \onlynumberslink #1 #2  {
+    \tl_set:Nn \l_onlynumberslink_tl {#1}
+    \regex_replace_all:nnN {[^0-9+]} {} \l_onlynumberslink_tl
+    \href{ tel\token_to_str:N : \tl_use:N \l_onlynumberslink_tl}{ #2 }
+}
+\ExplSyntaxOff
 
 % cvcolumns environment, where every column is created through \cvcolumn
 % usage: \begin{cvcolumns}


### PR DESCRIPTION
Title of the PDF included extra " - " characters even if title was empty.