### PR TITLE
Fix typo

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -129,8 +129,8 @@
     bookmarksdepth= 2,% to show sections and subsections
     pdfauthor     = {\@firstname{}~\@lastname{}},
     pdftitle      = {\@firstname{}~\@lastname{}\notblank{\@title}{ -- \@title}{}},
-    pdfsubject    = {Resum\'{e} of \@firstname{}~\@lastname{}},
-    pdfkeywords   = {\@firstname{}~\@lastname{}, curriculum vit\ae{}, resum\'{e}}}}
+    pdfsubject    = {R\'{e}sum\'{e} of \@firstname{}~\@lastname{}},
+    pdfkeywords   = {\@firstname{}~\@lastname{}, curriculum vit\ae{}, r\'{e}sum\'{e}}}}
 
 % graphics
 \RequirePackage{graphicx}


### PR DESCRIPTION
The right spelling of résumé has two acute accents. No accents is also OK in English, but just having the last accent is not.