### PR TITLE
Support ORCID and ResearchGate as \social

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -268,6 +268,8 @@
       \ifthenelse{\equal{#1}{github}}  {\collectionadd[github]{socials}  {\protect\httplink[#3]{www.github.com/#3}}}      {}%
       \ifthenelse{\equal{#1}{gitlab}}  {\collectionadd[gitlab]{socials}  {\protect\httplink[#3]{www.gitlab.com/#3}}}      {}%
       \ifthenelse{\equal{#1}{skype}}   {\collectionadd[skype]{socials}   {#3}}                                            {}%
+      \ifthenelse{\equal{#1}{orcid}}   {\collectionadd[orcid]{socials}   {\protect\httplink[#3]{orcid.org/#3}}}          {}%
+      \ifthenelse{\equal{#1}{researchgate}}{\collectionadd[researchgate]{socials}{\protect\httplink[#3]{www.researchgate.net/profile/#3}}}{}%
     }
     {\collectionadd[#1]{socials}{\protect\httplink[#3]{#2}}}}
 
@@ -310,6 +312,8 @@
 \newcommand*{\githubsocialsymbol}  {}
 \newcommand*{\gitlabsocialsymbol}  {}
 \newcommand*{\skypesocialsymbol}   {}
+\newcommand*{\orcidsocialsymbol}   {}
+\newcommand*{\researchgatesocialsymbol}{}
 
 % other
 %------

--- a/moderncviconsacademicons.sty
+++ b/moderncviconsacademicons.sty
@@ -1,0 +1,16 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncviconsacademicons}[2016/12/09 modern curriculum vitae and letter icons: academicons]
+
+\RequirePackage{academicons}
+
+\renewcommand*{\addresssymbol}           {}
+\renewcommand*{\mobilephonesymbol}       {}
+\renewcommand*{\fixedphonesymbol}        {}
+\renewcommand*{\faxphonesymbol}          {}
+\renewcommand*{\emailsymbol}             {}
+\renewcommand*{\homepagesymbol}          {}
+\renewcommand*{\linkedinsocialsymbol}    {}
+\renewcommand*{\twittersocialsymbol}     {}
+\renewcommand*{\githubsocialsymbol}      {}
+\renewcommand*{\orcidsocialsymbol}       {{\small\aiOrcid}~} % or \aiOrcidSquare
+\renewcommand*{\researchgatesocialsymbol}{{\small\aiResearchGate}~} % or \aiResearchGateSquare

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -39,6 +39,8 @@
 \renewcommand*{\githubsocialsymbol}  {{\small\faGithub}~}             % alternative: \faGithubSquare, \faGithubSquare
 \renewcommand*{\gitlabsocialsymbol}  {{\small\faGitlab}~}
 \renewcommand*{\skypesocialsymbol}   {{\small\faSkype}~}
+\renewcommand*{\orcidsocialsymbol}   {}
+\renewcommand*{\researchgatesocialsymbol}{}
 
 
 \endinput

--- a/moderncviconsletters.sty
+++ b/moderncviconsletters.sty
@@ -46,6 +46,8 @@
 \renewcommand*{\githubsocialsymbol}  {\textbf{gh}~}
 \renewcommand*{\gitlabsocialsymbol}  {\textbf{gl}~}
 \renewcommand*{\skypesocialsymbol}   {\textbf{sk}~}
+\renewcommand*{\orcidsocialsymbol}   {\textbf{iD}~}
+\renewcommand*{\researchgatesocialsymbol}{\textbf{RG}~}
 
 \renewcommand*{\listitemsymbol}      {\labelitemi~}
 

--- a/moderncviconsmarvosym.sty
+++ b/moderncviconsmarvosym.sty
@@ -257,6 +257,8 @@
       \protect\end{scope}%
     \protect\end{tikzpicture}}%
   ~}
+\renewcommand*{\orcidsocialsymbol}       {}
+\renewcommand*{\researchgatesocialsymbol}{}
 
 
 \endinput


### PR DESCRIPTION
I already reported in https://bugs.launchpad.net/moderncv/+bug/1615169, but no response.

usage:
```tex
\social[orcid]{0000-0000-0000-0000}
\social[researchgate]{john-smith}
```