### PR TITLE
added bitbucket option to \social

### DIFF
--- a/examples/template-multibib.tex
+++ b/examples/template-multibib.tex
@@ -37,6 +37,7 @@
 \social[twitter]{jdoe}                             % optional, remove / comment the line if not wanted
 \social[github]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[gitlab]{jdoe}                              % optional, remove / comment the line if not wanted
+\social[bitbucket]{jdoe}                           % optional, remove / comment the line if not wanted
 \social[skype]{jdoe}                               % optional, remove / comment the line if not wanted
 \extrainfo{additional information}                 % optional, remove / comment the line if not wanted
 \photo[64pt][0.4pt]{picture}                       % optional, remove / comment the line if not wanted; '64pt' is the height the picture must be resized to, 0.4pt is the thickness of the frame around it (put it to 0pt for no frame) and 'picture' is the name of the picture file

--- a/examples/template.tex
+++ b/examples/template.tex
@@ -37,6 +37,7 @@
 \social[twitter]{jdoe}                             % optional, remove / comment the line if not wanted
 \social[github]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[gitlab]{jdoe}                              % optional, remove / comment the line if not wanted
+\social[bitbucket]{jdoe}                           % optional, remove / comment the line if not wanted
 \social[skype]{jdoe}                               % optional, remove / comment the line if not wanted
 \extrainfo{additional information}                 % optional, remove / comment the line if not wanted
 \photo[64pt][0.4pt]{picture}                       % optional, remove / comment the line if not wanted; '64pt' is the height the picture must be resized to, 0.4pt is the thickness of the frame around it (put it to 0pt for no frame) and 'picture' is the name of the picture file

--- a/moderncv.cls
+++ b/moderncv.cls
@@ -257,17 +257,18 @@
 
 % adds a social link to one's personal information (optional)
 % usage: \social[<optional type>][<optional url>]{<account name>}
-% where <optional type> should be either "linkedin", "xing", "twitter", "github", "gitlab" or "skype"
+% where <optional type> should be either "linkedin", "xing", "twitter", "github", "gitlab", "bitbucket" or "skype"
 \collectionnew{socials}
 \NewDocumentCommand{\social}{O{}O{}m}{%
   \ifthenelse{\equal{#2}{}}%
     {%
-      \ifthenelse{\equal{#1}{linkedin}}{\collectionadd[linkedin]{socials}{\protect\httplink[#3]{www.linkedin.com/in/#3}}} {}%
-      \ifthenelse{\equal{#1}{xing}}    {\collectionadd[xing]{socials}    {\protect\httplink[#3]{www.xing.com/profile/#3}}}{}%
-      \ifthenelse{\equal{#1}{twitter}} {\collectionadd[twitter]{socials} {\protect\httplink[#3]{www.twitter.com/#3}}}     {}%
-      \ifthenelse{\equal{#1}{github}}  {\collectionadd[github]{socials}  {\protect\httplink[#3]{www.github.com/#3}}}      {}%
-      \ifthenelse{\equal{#1}{gitlab}}  {\collectionadd[gitlab]{socials}  {\protect\httplink[#3]{www.gitlab.com/#3}}}      {}%
-      \ifthenelse{\equal{#1}{skype}}   {\collectionadd[skype]{socials}   {#3}}                                            {}%
+      \ifthenelse{\equal{#1}{linkedin}} {\collectionadd[linkedin]{socials} {\protect\httplink[#3]{www.linkedin.com/in/#3}}} {}%
+      \ifthenelse{\equal{#1}{xing}}     {\collectionadd[xing]{socials}     {\protect\httplink[#3]{www.xing.com/profile/#3}}}{}%
+      \ifthenelse{\equal{#1}{twitter}}  {\collectionadd[twitter]{socials}  {\protect\httplink[#3]{www.twitter.com/#3}}}     {}%
+      \ifthenelse{\equal{#1}{github}}   {\collectionadd[github]{socials}   {\protect\httplink[#3]{www.github.com/#3}}}      {}%
+      \ifthenelse{\equal{#1}{gitlab}}   {\collectionadd[gitlab]{socials}   {\protect\httplink[#3]{www.gitlab.com/#3}}}      {}%
+      \ifthenelse{\equal{#1}{bitbucket}}{\collectionadd[bitbucket]{socials}{\protect\httplink[#3]{www.bitbucket.org/#3}}}   {}%
+      \ifthenelse{\equal{#1}{skype}}    {\collectionadd[skype]{socials}    {#3}}                                            {}%
     }
     {\collectionadd[#1]{socials}{\protect\httplink[#3]{#2}}}}
 
@@ -297,19 +298,20 @@
 \renewcommand{\theenumiv}          {\@Alph\c@enumiv}
 
 % other symbols
-\newcommand*{\listitemsymbol}      {\labelitemi~}
-\newcommand*{\addresssymbol}       {}
-\newcommand*{\mobilephonesymbol}   {}
-\newcommand*{\fixedphonesymbol}    {}
-\newcommand*{\faxphonesymbol}      {}
-\newcommand*{\emailsymbol}         {}
-\newcommand*{\homepagesymbol}      {}
-\newcommand*{\linkedinsocialsymbol}{}
-\newcommand*{\xingsocialsymbol}    {}
-\newcommand*{\twittersocialsymbol} {}
-\newcommand*{\githubsocialsymbol}  {}
-\newcommand*{\gitlabsocialsymbol}  {}
-\newcommand*{\skypesocialsymbol}   {}
+\newcommand*{\listitemsymbol}       {\labelitemi~}
+\newcommand*{\addresssymbol}        {}
+\newcommand*{\mobilephonesymbol}    {}
+\newcommand*{\fixedphonesymbol}     {}
+\newcommand*{\faxphonesymbol}       {}
+\newcommand*{\emailsymbol}          {}
+\newcommand*{\homepagesymbol}       {}
+\newcommand*{\linkedinsocialsymbol} {}
+\newcommand*{\xingsocialsymbol}     {}
+\newcommand*{\twittersocialsymbol}  {}
+\newcommand*{\githubsocialsymbol}   {}
+\newcommand*{\gitlabsocialsymbol}   {}
+\newcommand*{\bitbucketsocialsymbol}{}
+\newcommand*{\skypesocialsymbol}    {}
 
 % other
 %------

--- a/moderncviconsawesome.sty
+++ b/moderncviconsawesome.sty
@@ -27,18 +27,19 @@
 %\renewcommand*{\labelitemiii}        {\strut\textcolor{color1}{\rmfamily\textperiodcentered}}% no change from default in moderncv.cls
 %\renewcommand*{\labelitemiv}         {\labelitemiii}                                         % no change from default in moderncv.cls
 
-\renewcommand*{\addresssymbol}       {}
-\renewcommand*{\mobilephonesymbol}   {{\Large\faMobilePhone}~}
-\renewcommand*{\fixedphonesymbol}    {\faPhone~}
-\renewcommand*{\faxphonesymbol}      {{\small\faFax}~}                % alternative: \faPrint
-\renewcommand*{\emailsymbol}         {{\small\faEnvelopeO}~}          % alternative: \faInbox
-\renewcommand*{\homepagesymbol}      {{\small\faGlobe}~}              % alternative: \faHome
-\renewcommand*{\linkedinsocialsymbol}{{\small\faLinkedin}~}           % alternative: \faLinkedinSquare
-\renewcommand*{\xingsocialsymbol}    {{\small\faXing}~}               % alternative: \faXingSquare
-\renewcommand*{\twittersocialsymbol} {{\small\faTwitter}~}            % alternative: \faTwitterSquare
-\renewcommand*{\githubsocialsymbol}  {{\small\faGithub}~}             % alternative: \faGithubSquare, \faGithubSquare
-\renewcommand*{\gitlabsocialsymbol}  {{\small\faGitlab}~}
-\renewcommand*{\skypesocialsymbol}   {{\small\faSkype}~}
+\renewcommand*{\addresssymbol}        {}
+\renewcommand*{\mobilephonesymbol}    {{\Large\faMobilePhone}~}
+\renewcommand*{\fixedphonesymbol}     {\faPhone~}
+\renewcommand*{\faxphonesymbol}       {{\small\faFax}~}                % alternative: \faPrint
+\renewcommand*{\emailsymbol}          {{\small\faEnvelopeO}~}          % alternative: \faInbox
+\renewcommand*{\homepagesymbol}       {{\small\faGlobe}~}              % alternative: \faHome
+\renewcommand*{\linkedinsocialsymbol} {{\small\faLinkedin}~}           % alternative: \faLinkedinSquare
+\renewcommand*{\xingsocialsymbol}     {{\small\faXing}~}               % alternative: \faXingSquare
+\renewcommand*{\twittersocialsymbol}  {{\small\faTwitter}~}            % alternative: \faTwitterSquare
+\renewcommand*{\githubsocialsymbol}   {{\small\faGithub}~}             % alternative: \faGithubSquare, \faGithubSquare
+\renewcommand*{\gitlabsocialsymbol}   {{\small\faGitlab}~}
+\renewcommand*{\bitbucketsocialsymbol}{{\small\faBitbucket}~}
+\renewcommand*{\skypesocialsymbol}    {{\small\faSkype}~}
 
 
 \endinput

--- a/moderncviconsletters.sty
+++ b/moderncviconsletters.sty
@@ -34,18 +34,19 @@
 %\renewcommand*{\labelitemiii}        {\strut\textcolor{color1}{\rmfamily\textperiodcentered}}% no change from default in moderncv.cls
 %\renewcommand*{\labelitemiv}         {\labelitemiii}                                         % no change from default in moderncv.cls
 
-\renewcommand*{\addresssymbol}       {}
-\renewcommand*{\mobilephonesymbol}   {\textbf{M}~}
-\renewcommand*{\fixedphonesymbol}    {\textbf{T}~}
-\renewcommand*{\faxphonesymbol}      {\textbf{F}~}
-\renewcommand*{\emailsymbol}         {\textbf{E}~}
-\renewcommand*{\homepagesymbol}      {\textbf{W}~}
-\renewcommand*{\linkedinsocialsymbol}{\textbf{in}~}
-\renewcommand*{\xingsocialsymbol}    {\textbf{xi}~}
-\renewcommand*{\twittersocialsymbol} {\textbf{tw}~}
-\renewcommand*{\githubsocialsymbol}  {\textbf{gh}~}
-\renewcommand*{\gitlabsocialsymbol}  {\textbf{gl}~}
-\renewcommand*{\skypesocialsymbol}   {\textbf{sk}~}
+\renewcommand*{\addresssymbol}        {}
+\renewcommand*{\mobilephonesymbol}    {\textbf{M}~}
+\renewcommand*{\fixedphonesymbol}     {\textbf{T}~}
+\renewcommand*{\faxphonesymbol}       {\textbf{F}~}
+\renewcommand*{\emailsymbol}          {\textbf{E}~}
+\renewcommand*{\homepagesymbol}       {\textbf{W}~}
+\renewcommand*{\linkedinsocialsymbol} {\textbf{in}~}
+\renewcommand*{\xingsocialsymbol}     {\textbf{xi}~}
+\renewcommand*{\twittersocialsymbol}  {\textbf{tw}~}
+\renewcommand*{\githubsocialsymbol}   {\textbf{gh}~}
+\renewcommand*{\gitlabsocialsymbol}   {\textbf{gl}~}
+\renewcommand*{\bitbucketsocialsymbol}{\textbf{bb}~}
+\renewcommand*{\skypesocialsymbol}    {\textbf{sk}~}
 
 \renewcommand*{\listitemsymbol}      {\labelitemi~}
 

--- a/moderncviconsmarvosym.sty
+++ b/moderncviconsmarvosym.sty
@@ -224,6 +224,7 @@
     \protect\end{tikzpicture}}%
   ~}
 \renewcommand*{\gitlabsocialsymbol}{}
+\renewcommand*{\bitbucketsocialsymbol}{}
 \renewcommand*{\skypesocialsymbol}  {%
   \protect\raisebox{-0.15em}{%
     \protect\begin{tikzpicture}[y=0.08em, x=0.08em, xscale=0.020, yscale=-0.020, inner sep=0pt, outer sep=0pt]


### PR DESCRIPTION
This adds a `bitbucket` option to the `\social` command, just in line with the other supported VCS hosters.