### PR TITLE
Support HTTPS homepage URLs and deprecate the \httplink macro

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+version 2.1.0 (unreleased)
+ - Deprecate the \httplink macro as it was too inflexible and did only support
+ links to URLs using the (legacy) HTTP schema and not the new default HTTPS. Use \link.
+ - Change the format of the \homepage macro to support HTTPS homepage URLs.
+ Note that you will need to update your \homepage calls to make it work with
+ the new version.
+ - Switche \social URLs to HTTPS which has long been the default for all the
+ sites supported by \social.
+
 version 2.0.0 (28 Jul 2015)
  - refactored the  code into heads, body, foot and icon substyles. All styles
  (classic, casual, banking and oldstyle) are just a combination of these and

--- a/examples/template-es.tex
+++ b/examples/template-es.tex
@@ -28,9 +28,9 @@
 \address{calle y n\'umero}{c\'odigo postal y ciudad} % dato opcional, elimine la linea si no desea el dato
 \phone[mobile]{+1~(234)~567~890}                     % dato opcional, elimine la linea si no desea el dato
 \phone[fixed]{+2~(345)~678~901}                      % dato opcional, elimine la linea si no desea el dato
-\phone[fax]{+3~(456)~789~012}                       % dato opcional, elimine la linea si no desea el dato
+\phone[fax]{+3~(456)~789~012}                        % dato opcional, elimine la linea si no desea el dato
 \email{john@doe.org}                                 % dato opcional, elimine la linea si no desea el dato
-\homepage{www.johndoe.com}                           % dato opcional, elimine la linea si no desea el dato
+\homepage{https://www.johndoe.com}{www.johndoe.com}  % dato opcional, elimine la linea si no desea el dato
 \extrainfo{informacion adicional}                    % dato opcional, elimine la linea si no desea el dato
 \photo[64pt][0.4pt]{picture}                         % '64pt' es la altura a la que la imagen debe ser ajustada, 0.4pt es grosor del marco que lo contiene (eliga 0pt para eliminar el marco) y 'picture' es el nombre del archivo; dato opcional, elimine la linea si no desea el dato
 \quote{Alguna cita (opcional)}                       % dato opcional, elimine la linea si no desea el dato

--- a/examples/template-multibib.tex
+++ b/examples/template-multibib.tex
@@ -31,9 +31,9 @@
 \phone[fixed]{+2~(345)~678~901}
 \phone[fax]{+3~(456)~789~012}
 \email{john@doe.org}                               % optional, remove / comment the line if not wanted
-\homepage{www.johndoe.com}                         % optional, remove / comment the line if not wanted
+\homepage{https://www.johndoe.com}{www.johndoe.com}% optional, remove / comment the line if not wanted
 \social[linkedin]{john.doe}                        % optional, remove / comment the line if not wanted
-\social[xing]{john\_doe}                           % optional, remove / comment the line if not wanted
+\social[xing]{john\textunderscore doe}             % optional, remove / comment the line if not wanted
 \social[twitter]{jdoe}                             % optional, remove / comment the line if not wanted
 \social[github]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[gitlab]{jdoe}                              % optional, remove / comment the line if not wanted

--- a/examples/template-zh.tex
+++ b/examples/template-zh.tex
@@ -29,7 +29,7 @@
 \phone[fixed]{+2~(345)~678~901}               % 可选项、如不需要可删除本行
 \phone[fax]{+3~(456)~789~012}                 % 可选项、如不需要可删除本行
 \email{xiaolong@li.com.cn}                    % 可选项、如不需要可删除本行
-\homepage{www.xialongli.com}                  % 可选项、如不需要可删除本行
+\homepage{https://www.xialongli.com}{www.xialongli.com} % 可选项、如不需要可删除本行
 \extrainfo{附加信息 (可选项)}                 % 可选项、如不需要可删除本行
 \photo[64pt][0.4pt]{picture}                  % ‘64pt’是图片必须压缩至的高度、‘0.4pt‘是图片边框的宽度 (如不需要可调节至0pt)、’picture‘ 是图片文件的名字;可选项、如不需要可删除本行
 \quote{引言(可选项)}                          % 可选项、如不需要可删除本行

--- a/examples/template.tex
+++ b/examples/template.tex
@@ -31,9 +31,9 @@
 \phone[fixed]{+2~(345)~678~901}
 \phone[fax]{+3~(456)~789~012}
 \email{john@doe.org}                               % optional, remove / comment the line if not wanted
-\homepage{www.johndoe.com}                         % optional, remove / comment the line if not wanted
+\homepage{https://www.johndoe.com}{www.johndoe.com}% optional, remove / comment the line if not wanted
 \social[linkedin]{john.doe}                        % optional, remove / comment the line if not wanted
-\social[xing]{john\_doe}                           % optional, remove / comment the line if not wanted
+\social[xing]{john\textunderscore doe}             % optional, remove / comment the line if not wanted
 \social[twitter]{jdoe}                             % optional, remove / comment the line if not wanted
 \social[github]{jdoe}                              % optional, remove / comment the line if not wanted
 \social[gitlab]{jdoe}                              % optional, remove / comment the line if not wanted

--- a/manual/moderncv_userguide.tex
+++ b/manual/moderncv_userguide.tex
@@ -443,7 +443,6 @@ In particular, the first column, can be set to any width. You can do that in two
 There are commands to manage hypertextual links:
 \begin{itemize}
  \item[-] \verb|\weblink[optional text]{link}|
- \item[-] \verb|\httplink[optional text]{link}|
  \item[-] \verb|\emaillink[optional text]{link}|
 \end{itemize}
 

--- a/moderncv.cls
+++ b/moderncv.cls
@@ -241,8 +241,11 @@
 \newcommand*{\email}[1]{\def\@email{#1}}
 
 % defines one's home page (optional)
-% usage: \homepage{<url>}
-\newcommand*{\homepage}[1]{\def\@homepage{#1}}
+% usage: \homepage{<url>}{home page text}
+\newcommand*{\homepage}[2]{
+  \def\@homepage@url{#1}
+  \def\@homepage@text{#2}
+}
 
 % adds a fixed/mobile/fax number to one's personal information (optional)
 % usage: \phone[<optional type>]{<number>}
@@ -262,14 +265,14 @@
 \NewDocumentCommand{\social}{O{}O{}m}{%
   \ifthenelse{\equal{#2}{}}%
     {%
-      \ifthenelse{\equal{#1}{linkedin}}{\collectionadd[linkedin]{socials}{\protect\httplink[#3]{www.linkedin.com/in/#3}}} {}%
-      \ifthenelse{\equal{#1}{xing}}    {\collectionadd[xing]{socials}    {\protect\httplink[#3]{www.xing.com/profile/#3}}}{}%
-      \ifthenelse{\equal{#1}{twitter}} {\collectionadd[twitter]{socials} {\protect\httplink[#3]{www.twitter.com/#3}}}     {}%
-      \ifthenelse{\equal{#1}{github}}  {\collectionadd[github]{socials}  {\protect\httplink[#3]{www.github.com/#3}}}      {}%
-      \ifthenelse{\equal{#1}{gitlab}}  {\collectionadd[gitlab]{socials}  {\protect\httplink[#3]{www.gitlab.com/#3}}}      {}%
+      \ifthenelse{\equal{#1}{linkedin}}{\collectionadd[linkedin]{socials}{\protect\link[#3]{https://www.linkedin.com/in/#3}}} {}%
+      \ifthenelse{\equal{#1}{xing}}    {\collectionadd[xing]{socials}    {\protect\link[#3]{https://www.xing.com/profile/#3}}}{}%
+      \ifthenelse{\equal{#1}{twitter}} {\collectionadd[twitter]{socials} {\protect\link[#3]{https://www.twitter.com/#3}}}     {}%
+      \ifthenelse{\equal{#1}{github}}  {\collectionadd[github]{socials}  {\protect\link[#3]{https://www.github.com/#3}}}      {}%
+      \ifthenelse{\equal{#1}{gitlab}}  {\collectionadd[gitlab]{socials}  {\protect\link[#3]{https://www.gitlab.com/#3}}}      {}%
       \ifthenelse{\equal{#1}{skype}}   {\collectionadd[skype]{socials}   {#3}}                                            {}%
     }
-    {\collectionadd[#1]{socials}{\protect\httplink[#3]{#2}}}}
+    {\collectionadd[#1]{socials}{\protect\link[#3]{#2}}}}
 
 % defines additional personal information (optional)
 % usage: \extrainfo{<text>}
@@ -499,13 +502,6 @@
   \ifthenelse{\equal{#1}{}}%
     {\href{#2}{#2}}%
     {\href{#2}{#1}}}
-
-% makes a http hyperlink
-% usage: \httplink[optional text]{link}
-\newcommand*{\httplink}[2][]{%
-  \ifthenelse{\equal{#1}{}}%
-    {\href{http://#2}{#2}}%
-    {\href{http://#2}{#1}}}
 
 % makes an email hyperlink
 % usage: \emaillink[optional text]{link}

--- a/moderncvcompatibility.sty
+++ b/moderncvcompatibility.sty
@@ -100,6 +100,13 @@
 % compatibility with versions <= 1.5.1
 \newcommand*{\makecvtitlenamewidth}{\makecvheadnamewidth} % only used in header variants 1 and 4, themself used by the classic and oldstyle styles
 
+% compatibility with versions <= 2.0.0
+% HTTP is considered legacy, this command only allows to use the HTTP URL scheme and is thus considered legacy as well. Use \link.
+% usage: \httplink[optional text]{http host}
+\newcommand*{\httplink}[2][]{%
+  \ifthenelse{\equal{#1}{}}%
+    {\href{http://#2}{#2}}%
+    {\href{http://#2}{#1}}}
 
 \endinput
 

--- a/moderncvfooti.sty
+++ b/moderncvfooti.sty
@@ -88,7 +88,7 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \addtofoot{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
         \ifthenelse{\isundefined{\@email}}{}{\addtofoot{\emailsymbol\emaillink{\@email}}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\addtofoot{\homepagesymbol\httplink{\@homepage}}}%
+        \ifthenelse{\isundefined{\@homepage@url}}{}{\addtofoot{\homepagesymbol\link[\@homepage@text]{\@homepage@url}}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
           \addtofoot{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\addtofoot{\@extrainfo}}%
@@ -119,7 +119,7 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \addtofoot{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
         \ifthenelse{\isundefined{\@email}}{}{\addtofoot{\emailsymbol\emaillink{\@email}}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\addtofoot{\homepagesymbol\httplink{\@homepage}}}%
+        \ifthenelse{\isundefined{\@homepage@url}}{}{\addtofoot{\homepagesymbol\link[\@homepage@text]{\@homepage@url}}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
           \addtofoot{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\addtofoot{\@extrainfo}}%

--- a/moderncvheadi.sty
+++ b/moderncvheadi.sty
@@ -80,7 +80,7 @@
           \ifthenelse{\equal{\@addresscountry}{}}{}{\makenewline\@addresscountry}}%
         \phonesdetails% needs to be pre-rendered as loops and tabulars seem to conflict
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httplink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage@url}}{}{\makenewline\homepagesymbol\link[\@homepage@text]{\@homepage@url}}%
         \socialsdetails% needs to be pre-rendered as loops and tabulars seem to conflict
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}%
       \end{tabular}
@@ -158,7 +158,7 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httplink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage@url}}{}{\makenewline\homepagesymbol\link[\@homepage@text]{\@homepage@url}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi%
     \end{minipage}\\[1em]
   % recipient block

--- a/moderncvheadii.sty
+++ b/moderncvheadii.sty
@@ -143,7 +143,7 @@
     \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
       \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
     \ifthenelse{\isundefined{\@email}}{}{\addtomakeheaddetails{\emailsymbol\emaillink{\@email}}}%
-    \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol\httplink{\@homepage}}}%
+    \ifthenelse{\isundefined{\@homepage@url}}{}{\addtomakeheaddetails{\homepagesymbol\link[\@homepage@text]{\@homepage@url}}}%
     \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
       \addtomakeheaddetails{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
     \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%

--- a/moderncvheadiii.sty
+++ b/moderncvheadiii.sty
@@ -92,7 +92,7 @@
       \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
         \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
       \ifthenelse{\isundefined{\@email}}{}{\addtomakeheaddetails{\emailsymbol\emaillink{\@email}}}%
-      \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol\httplink{\@homepage}}}%
+      \ifthenelse{\isundefined{\@homepage@url}}{}{\addtomakeheaddetails{\homepagesymbol\link[\@homepage@text]{\@homepage@url}}}%
       \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
         \addtomakeheaddetails{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
       \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%

--- a/moderncvheadiv.sty
+++ b/moderncvheadiv.sty
@@ -110,7 +110,7 @@
       \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
         \makenewline\hbox to 1.0em{\csname\collectionloopkey phonesymbol\endcsname}~\collectionloopitem}%
       \ifthenelse{\isundefined{\@email}}{}{\makenewline\hbox to 1.0em{\emailsymbol}~\emaillink{\@email}}%
-      \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~\httplink{\@homepage}}%
+      \ifthenelse{\isundefined{\@homepage@url}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~\link[\@homepage@text]{\@homepage@url}}%
       \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
         \makenewline\hbox to 1.0em{\csname\collectionloopkey socialsymbol\endcsname}~\collectionloopitem}%
       \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi}
@@ -156,7 +156,7 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\hbox to 1.0em{\csname\collectionloopkey phonesymbol\endcsname}~\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\hbox to 1.0em{\emailsymbol}~\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~\httplink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage@url}}{}{\makenewline\hbox to 1.0em{\homepagesymbol}~\link[\@homepage@text]{\@homepage@url}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
           \makenewline\hbox to 1.0em{\csname\collectionloopkey socialsymbol\endcsname}~\collectionloopitem}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}}%

--- a/moderncvheadv.sty
+++ b/moderncvheadv.sty
@@ -82,7 +82,7 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\csname\collectionloopkey phonesymbol\endcsname~\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol~\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol~\httplink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage@url}}{}{\makenewline\homepagesymbol~\link[\@homepage@text]{\@homepage@url}}%
         \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
           \makenewline\csname\collectionloopkey socialsymbol\endcsname~\collectionloopitem}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}\fi}%
@@ -140,7 +140,7 @@
         \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
           \makenewline\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}%
         \ifthenelse{\isundefined{\@email}}{}{\makenewline\emailsymbol\emaillink{\@email}}%
-        \ifthenelse{\isundefined{\@homepage}}{}{\makenewline\homepagesymbol\httplink{\@homepage}}%
+        \ifthenelse{\isundefined{\@homepage@url}}{}{\makenewline\homepagesymbol\link[\@homepage@text]{\@homepage@url}}%
         \ifthenelse{\isundefined{\@extrainfo}}{}{\makenewline\@extrainfo}}\fi%
     \end{minipage}\\[1em]
   % recipient block

--- a/moderncvheadvi.sty
+++ b/moderncvheadvi.sty
@@ -115,7 +115,7 @@
     \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
       \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
     \ifthenelse{\isundefined{\@email}}{}{\addtomakeheaddetails{\emailsymbol\emaillink{\@email}}}%
-    \ifthenelse{\isundefined{\@homepage}}{}{\addtomakeheaddetails{\homepagesymbol\httplink{\@homepage}}}%
+    \ifthenelse{\isundefined{\@homepage@url}}{}{\addtomakeheaddetails{\homepagesymbol\link[\@homepage@text]{\@homepage@url}}}%
     \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link
       \addtomakeheaddetails{\csname\collectionloopkey socialsymbol\endcsname\collectionloopitem}}%
     \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%


### PR DESCRIPTION
- Deprecate the \httplink macro as it was too inflexible and did only support links to URLs using the (legacy) HTTP schema and not the new default HTTPS. Use \link.
- Change the format of the \homepage macro to support HTTPS homepage URLs.
  Note that you will need to update your \homepage calls to make it work with the new version.
- Switch \social URLs to HTTPS which has long been the default for all the sites supported by \social.

Partly mechanical edit:

```Shell
git ls-files -z "$(git rev-parse --show-toplevel)" | xargs --null -I '{}' find '{}' -type f -print0 | xargs --null sed --in-place --regexp-extended 's#\\isundefined\{\\@homepage\}#\\isundefined{\\@homepage@url}#g;s#\\httplink\{\\@homepage\}#\\link\[\\@homepage@text\]\{\\@homepage@url\}#g;'
```

Closes: https://github.com/xdanaux/moderncv/issues/6
Related patchset: xdanaux#40

There should be *no* reason for people to downgrade to http links just because moderncv only supports legacy URL schemes. Ref: https://github.com/gshakhn/resume/commit/b8c93b97bd5c1648198536d7a8ad74e929a57871