### PR TITLE
Removed unnecessary line break for the banking style

### DIFF
--- a/moderncvheadiii.sty
+++ b/moderncvheadiii.sty
@@ -88,7 +88,7 @@
       \ifthenelse{\isundefined{\@addressstreet}}{}{\addtomakeheaddetails{\addresssymbol\@addressstreet}%
         \ifthenelse{\equal{\@addresscity}{}}{}{\addtomakeheaddetails[~--~]{\@addresscity}}% if \addresstreet is defined, \addresscity and \addresscountry will always be defined but could be empty
         \ifthenelse{\equal{\@addresscountry}{}}{}{\addtomakeheaddetails[~--~]{\@addresscountry}}%
-        \flushmakeheaddetails\@firstmakeheaddetailselementtrue\\\null}%
+        \flushmakeheaddetails\@firstmakeheaddetailselementtrue\\}%
       \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
         \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
       \ifthenelse{\isundefined{\@email}}{}{\addtomakeheaddetails{\emailsymbol\emaillink{\@email}}}%


### PR DESCRIPTION
Hello,
this pull request removes the unnecessary line break between the address field and the others fields from the heading section of the banking style.