### PR TITLE
Switch from l3regex (obsolete) to expl3 package requirement

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -191,7 +191,7 @@
 % compatibility package with older versions of moderncv
 \RequirePackageWithOptions{moderncvcompatibility}
 
-\RequirePackage{l3regex}
+\RequirePackage{expl3}
 
 %-------------------------------------------------------------------------------
 %                class definition


### PR DESCRIPTION
From l3regex.sty (latest MikTeX):

```
\def\old@liii@module@name
{l3regex}
\ProvidesPackage\old@liii@module@name
  [%
    2017/03/18 Obsolete L3 package
  ]
\typeout{*****************************************************************}
\typeout{** }
\typeout{** Package \old@liii@module@name\space is obsolete and has been removed!}
\typeout{** }
\typeout{** Its functionality is now only provided as part of the expl3 package.}
\typeout{** }
\typeout{** The old packages will be removed entirely at the end of 2018.}
\typeout{** }
\typeout{** Therefore, please replace '\string\usepackage{\old@liii@module@name}'}
\typeout{** with '\string\usepackage{expl3}' in your documents as soon as possible.}
\typeout{** }
\typeout{*******************************************************************}
\PackageWarning
  \old@liii@module@name{This package is obsolete ---
   use 'expl3' instead}
\RequirePackage{expl3}
```

Right now, this edit only removes an annoying error when compiling a file, but will be required by the end of this year, apparently.