### PR TITLE
Changes \RequirePackage{l3regex} to \RequirePackage{expl3}

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -191,7 +191,7 @@
 % compatibility package with older versions of moderncv
 \RequirePackageWithOptions{moderncvcompatibility}
 
-\RequirePackage{l3regex}
+\RequirePackage{expl3}
 
 %-------------------------------------------------------------------------------
 %                class definition


### PR DESCRIPTION
l3regex is obsolete as of late 2018 and was merged with expl3