### PR TITLE
Bankingplus style and two new command helps for creating nested cventry

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -1,5 +1,6 @@
 %% start of file `moderncv.cls'.
 %% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com).
+%% Modification Copyright 2019-2019 Raju Rimal (therimalaya@gmail.com).
 %
 % This work may be distributed and/or modified under the
 % conditions of the LaTeX Project Public License version 1.3c,
@@ -488,6 +489,16 @@
 % makes a typical resume job / education entry
 % usage: \cventry[spacing]{years}{degree/job title}{institution/employer}{localization}{optionnal: grade/...}{optional: comment/job description}
 \newcommand*{\cventry}[7][.25em]{}
+
+% makes a resume entry which contains nested subentries
+% Removed the year and degree/job title from cventry. These items can be multiple and can be nested
+% usage: \cventryout[spacing]{years}{localization}{optional: comment/job description}
+\newcommand*{\cventryout}[4][.25em]{}
+
+% makes a resume entry which has removed institution/employer and localization
+% This can be used as nested item under cvhasnesedentry so that multiple items can be nested with same cventry
+% usage: \cventryin[spacing]{years}{degree/job title}{optional: comment/job description}
+\newcommand*{\cventryin}[4][.25em]{}
 
 % makes a resume entry with a proficiency comment
 % usage: \cvitemwithcomment[spacing]{header}{text}{comment}

--- a/moderncvbodyvii.sty
+++ b/moderncvbodyvii.sty
@@ -1,0 +1,261 @@
+%% start of file `moderncvbodyvii.sty'.
+%% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com).
+%% Copyright 2019-2019 Raju Rimal (therimalaya@gmail.com).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvbodyvii}[2019/10/30 v2.0.0 modern curriculum vitae and letter body variant: 7]
+
+% rules type options: "fullrules", "shortrules", "mixedrules" (default) or "norules"
+\@initializeif{\if@fullrules}\@fullrulesfalse
+\DeclareOption{fullrules} {\@fullrulestrue\@shortrulesfalse\@mixedrulesfalse\@norulesfalse}
+\@initializeif{\if@shortrules}\@shortrulesfalse
+\DeclareOption{shortrules}{\@fullrulesfalse\@shortrulestrue\@mixedrulesfalse\@norulesfalse}
+\@initializeif{\if@mixedrules}\@mixedrulesfalse
+\DeclareOption{mixedrules}{\@fullrulesfalse\@shortrulesfalse\@mixedrulestrue\@norulesfalse}
+\@initializeif{\if@norules}\@norulesfalse
+\DeclareOption{norules}   {\@fullrulesfalse\@shortrulesfalse\@mixedrulesfalse\@norulestrue}
+
+% section alignment options: "left" (default), "center" or "right"
+\@initializeif{\if@left}\@leftfalse
+\DeclareOption{left}      {\@lefttrue\@centerfalse\@rightfalse}
+\@initializeif{\if@center}\@centerfalse
+\DeclareOption{center}    {\@leftfalse\@centertrue\@rightfalse}
+\@initializeif{\if@right}\@rightfalse
+\DeclareOption{right}     {\@leftfalse\@centerfalse\@righttrue}
+
+\DeclareOption*{}% avoid choking on unknown options
+\ExecuteOptions{mixedrules,left}
+\ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
+
+%-------------------------------------------------------------------------------
+%                required packages
+%-------------------------------------------------------------------------------
+
+
+%-------------------------------------------------------------------------------
+%                overall body definition
+%-------------------------------------------------------------------------------
+% fonts
+\renewcommand*{\sectionfont}{%
+  \if@norules%
+    \Large\bfseries\scshape%
+  \else%
+    \Large\bfseries\upshape\fi}
+\renewcommand*{\subsectionfont}{%
+  \if@norules%
+    \large\mdseries\itshape%
+  \else%
+    \large\upshape\fontseries{sb}\selectfont\fi}
+\renewcommand*{\hintfont}{\bfseries}
+
+% styles
+\renewcommand*{\sectionstyle}[1]{{%
+  \if@center\centering\else%
+  \if@right\raggedleft\fi\fi%
+  \sectionfont\textcolor{color1}{#1}%
+  \if@shortrules\else%
+    \par\fi}}
+\renewcommand*{\subsectionstyle}[1]{{%
+  \if@center\centering\else%
+  \if@right\raggedleft\fi\fi%
+  \subsectionfont\textcolor{color1}{#1}%
+  \if@shortrules\else\if@mixedrules\else%
+    \par\fi\fi}}
+\renewcommand*{\hintstyle}[1]{{\hintfont\textcolor{color0}{#1}}}
+
+
+%-------------------------------------------------------------------------------
+%                resume body definition
+%-------------------------------------------------------------------------------
+% lengths
+%   used by \cvitem (and all children command)
+\@initializelength{\hintscolumnwidth}             \setlength{\hintscolumnwidth}{0.3\textwidth}
+\@initializelength{\separatorcolumnwidth}         \setlength{\separatorcolumnwidth}{0.025\textwidth}
+\@initializelength{\maincolumnwidth}
+%   used by \cvdoubleitem
+\@initializelength{\doubleitemcolumnwidth}
+%   used by \cvlistitem
+\@initializelength{\listitemsymbolwidth}          \settowidth{\listitemsymbolwidth}{\listitemsymbol}
+\@initializelength{\listitemcolumnwidth}
+%   used by \cvlistdoubleitem
+\@initializelength{\listdoubleitemcolumnwidth}
+
+% commands
+\renewcommand*{\recomputecvbodylengths}{%
+  % body lengths
+  \setlength{\maincolumnwidth}{\textwidth-\leftskip-\rightskip}%
+  \setlength{\listitemcolumnwidth}{\maincolumnwidth-\listitemsymbolwidth}%
+  \setlength{\doubleitemcolumnwidth}{\maincolumnwidth-\separatorcolumnwidth}%
+  \setlength{\doubleitemcolumnwidth}{0.5\doubleitemcolumnwidth}%
+  \setlength{\listdoubleitemcolumnwidth}{\maincolumnwidth-\listitemsymbolwidth-\separatorcolumnwidth-\listitemsymbolwidth}%
+  \setlength{\listdoubleitemcolumnwidth}{0.5\listdoubleitemcolumnwidth}%
+  % regular lengths
+  \setlength{\parskip}{0\p@}}
+
+\RenewDocumentCommand{\section}{sm}{%
+  \par\addvspace{2.5ex}%
+  \phantomsection{}% reset the anchor for hyperrefs
+  \addcontentsline{toc}{section}{#2}%
+  \if@left\else\if@fullrules\else\if@mixedrules\else%
+    \sectionrule\fi\fi\fi%
+  \strut\sectionstyle{#2}%
+  \if@fullrules%
+    \sectionrule%
+  \else\if@mixedrules%
+    \sectionrule%
+  \else\if@right\else%
+    \sectionrule\fi\fi\fi%
+  \par\nobreak\addvspace{1ex}\@afterheading}
+
+\RenewDocumentCommand{\subsection}{sm}{%
+  \par\addvspace{1ex}%
+  \phantomsection{}%
+  \addcontentsline{toc}{subsection}{#2}%
+  \if@left\else\if@fullrules\else%
+    \subsectionrule\fi\fi%
+  \strut\subsectionstyle{#2}%
+  \if@fullrules%
+    \subsectionrule%
+  \else\if@right\else%
+    \subsectionrule\fi\fi%
+  \par\nobreak\addvspace{0.5ex}\@afterheading}
+
+\newcommand*{\sectionrule}{}
+\newcommand*{\subsectionrule}{}
+\if@fullrules%
+  \renewcommand*{\sectionrule}{\par\nobreak\vspace*{-.7\baselineskip}\leavevmode{\color{color1}\leaders\hbox{\rule{1pt}{0.4pt}}\hfill\kern0pt}}
+  \renewcommand*{\subsectionrule}{\par\nobreak\vspace*{-.7\baselineskip}\leavevmode{\color{color1}\xleaders\hbox to 0.35em{\scriptsize.}\hfill}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}
+\if@shortrules%
+  \renewcommand*{\sectionrule}{\leavevmode{\color{color1}\leaders\hbox{\rule{1pt}{0.4pt}}\hfill\kern0pt}}
+  \renewcommand*{\subsectionrule}{\leavevmode{\color{color1}\xleaders\hbox to 0.35em{\scriptsize.}\hfill}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}}
+\if@mixedrules%
+  \renewcommand*{\sectionrule}{\par\nobreak\vspace*{-.7\baselineskip}\leavevmode{\color{color1}\leaders\hbox{\rule{1pt}{0.4pt}}\hfill\kern0pt}}
+  \renewcommand*{\subsectionrule}{\leavevmode{\color{color1}\xleaders\hbox to 0.35em{\scriptsize.}\hfill}}\fi% different subsectionrules will not be perfectly aligned, but remaining space at the end of the fill will be distributed evenly between leaders, so it will be barely visible}}
+\if@norules%
+  \renewcommand*{\sectionrule}{}
+  \renewcommand*{\subsectionrule}{}\fi
+
+\renewcommand*{\cvitem}[3][.25em]{%
+  \ifthenelse{\equal{#2}{}}{}{\hintstyle{#2}: }{#3}%
+  \par\addvspace{#1}}
+
+\renewcommand*{\cvdoubleitem}[5][.25em]{%
+  \begin{minipage}[t]{\doubleitemcolumnwidth}\hintstyle{#2}: #3\end{minipage}%
+  \hfill% fill of \separatorcolumnwidth
+  \begin{minipage}[t]{\doubleitemcolumnwidth}\ifthenelse{\equal{#4}{}}{}{\hintstyle{#4}: }#5\end{minipage}%
+  \par\addvspace{#1}}
+
+\renewcommand*{\cvlistitem}[2][.25em]{%
+  \listitemsymbol\begin{minipage}[t]{\listitemcolumnwidth}#2\end{minipage}%
+  \par\addvspace{#1}}
+
+\renewcommand*{\cvlistdoubleitem}[3][.25em]{%
+  \cvitem[#1]{}{\listitemsymbol\begin{minipage}[t]{\listdoubleitemcolumnwidth}#2\end{minipage}%
+  \hfill% fill of \separatorcolumnwidth
+  \ifthenelse{\equal{#3}{}}%
+    {}%
+    {\listitemsymbol\begin{minipage}[t]{\listdoubleitemcolumnwidth}#3\end{minipage}}}}
+
+\renewcommand*{\cventry}[7][.25em]{
+  \begin{tabular*}{\maincolumnwidth}{l@{\extracolsep{\fill}}r}%
+    {\bfseries #4} & {\bfseries #5}\\%
+    {\itshape #3\ifthenelse{\equal{#6}{}}{}{, #6}} & {\itshape #2}\\%
+  \end{tabular*}%
+  \ifx&#7&%
+  \else{\\%
+    \begin{minipage}{\maincolumnwidth}%
+      \small#7%
+    \end{minipage}}\fi%
+  \par\addvspace{#1}}
+
+\renewcommand*{\cventryout}[4][.25em]{
+  \begin{tabular*}{\maincolumnwidth}{l@{\extracolsep{\fill}}r}%
+    {\bfseries #2} & {\bfseries #3}\\%
+  \end{tabular*}%
+  \ifx&#4&%
+  \else{\vspace{0.5ex}\\%
+    \begin{minipage}{\maincolumnwidth}%
+      \small#4%
+    \end{minipage}}\fi%
+  \par\addvspace{#1}}
+
+\renewcommand*{\cventryin}[4][.25em]{
+  \begin{tabular*}{\maincolumnwidth}{l@{\extracolsep{\fill}}r}%
+    {\itshape #2} & {\itshape #3}\\%
+  \end{tabular*}%
+  \ifx&#4&%
+  \else{\vspace{0.5ex}\\%
+    \begin{minipage}{\maincolumnwidth}%
+      \small#4%
+    \end{minipage}}\fi%
+  \par\addvspace{#1}}
+
+\@initializebox{\cvitemwithcommentmainbox}
+\@initializelength{\cvitemwithcommentmainlength}
+\@initializelength{\cvitemwithcommentcommentlength}
+\renewcommand*{\cvitemwithcomment}[4][.25em]{%
+  \savebox{\cvitemwithcommentmainbox}{\ifthenelse{\equal{#2}{}}{}{\hintstyle{#2}: }#3}%
+  \setlength{\cvitemwithcommentmainlength}{\widthof{\usebox{\cvitemwithcommentmainbox}}}%
+  \setlength{\cvitemwithcommentcommentlength}{\maincolumnwidth-\separatorcolumnwidth-\cvitemwithcommentmainlength}%
+  \begin{minipage}[t]{\cvitemwithcommentmainlength}\usebox{\cvitemwithcommentmainbox}\end{minipage}%
+  \hfill% fill of \separatorcolumnwidth
+  \begin{minipage}[t]{\cvitemwithcommentcommentlength}\raggedleft\small\itshape#4\end{minipage}%
+  \par\addvspace{#1}}
+
+\renewenvironment{thebibliography}[1]%
+  {%
+    \bibliographyhead{\refname}%
+%    \small%
+    \begin{list}{\bibliographyitemlabel}%
+      {%
+        \setlength{\topsep}{0pt}%
+        \setlength{\labelwidth}{0pt}%
+        \ifthenelse{\equal{\bibliographyitemlabel}{}}%
+          {\setlength{\labelsep}{0pt}}%
+          {\setlength{\labelsep}{\separatorcolumnwidth}}%
+        \leftmargin\labelwidth%
+        \advance\leftmargin\labelsep%
+        \@openbib@code%
+        \usecounter{enumiv}%
+        \let\p@enumiv\@empty%
+        \renewcommand\theenumiv{\@arabic\c@enumiv}}%
+        \sloppy%
+        \clubpenalty4000%\@clubpenalty \clubpenalty%
+        \widowpenalty4000%
+        \sfcode`\.\@m%
+        \sfcode `\=1000\relax}%
+  {%
+    \def\@noitemerr{\@latex@warning{Empty `thebibliography' environment}}%
+    \end{list}}
+
+
+%-------------------------------------------------------------------------------
+%                letter style definition
+%-------------------------------------------------------------------------------
+% commands
+\renewcommand*{\recomputeletterbodylengths}{%
+  \recomputecvbodylengths%
+  \setlength{\parskip}{6\p@}}
+
+\renewcommand*{\makeletterclosing}{
+  \@closing\\[3em]%
+  {\bfseries\@firstname~\@lastname}%
+  \ifthenelse{\isundefined{\@enclosure}}{}{%
+    \\%
+    \vfil%
+    {\color{color2}\itshape\enclname: \@enclosure}}%
+    \vfil}
+
+
+\endinput
+
+
+%% end of file `moderncvbodyiii.sty'.

--- a/moderncvheadvii.sty
+++ b/moderncvheadvii.sty
@@ -1,0 +1,203 @@
+%% start of file `moderncvheadvii.sty'.
+%% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com).
+%% Copyright 2019-2019 Raju Rimal (therimalaya@gmail.com).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvheadvii}[2019/10/30 v2.0.0 modern curriculum vitae and letter header variant: 7]
+
+% details options: "details" (default) or "nodetails"
+\@initializeif{\if@details}\@detailsfalse
+\DeclareOption{details}{\@detailstrue}
+\DeclareOption{nodetails}{\@detailsfalse}
+
+\DeclareOption*{}% avoid choking on unknown options
+\ExecuteOptions{details}
+\ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
+
+%-------------------------------------------------------------------------------
+%                required packages
+%-------------------------------------------------------------------------------
+
+
+%-------------------------------------------------------------------------------
+%                overall head definition
+%-------------------------------------------------------------------------------
+% fonts
+\renewcommand*{\namefont}{\Huge\bfseries\upshape}
+\renewcommand*{\titlefont}{\Huge\mdseries\upshape}
+\renewcommand*{\addressfont}{\normalsize\mdseries\upshape}
+\renewcommand*{\quotefont}{\large\slshape}
+
+% styles
+\renewcommand*{\namestyle}[1]{{\namefont\textcolor{color1}{#1}}}
+\renewcommand*{\titlestyle}[1]{{\titlefont\textcolor{color2!85}{#1}}}
+\renewcommand*{\addressstyle}[1]{{\addressfont\textcolor{color2}{#1}}}
+\renewcommand*{\quotestyle}[1]{{\quotefont\textcolor{color1}{#1}}}
+
+% commands
+\@initializecommand{\makeheaddetailssymbol}{%
+    {~~~{\rmfamily\textbullet}~~~}}% the \rmfamily is required to force Latin Modern fonts when using sans serif, as OMS/lmss/m/n is not defined and gets substituted by OMS/cmsy/m/n
+%   internal command to add an element to the footer
+%   it collects the elements in a temporary box, and checks when to flush the box
+\@initializebox{\makeheaddetailsbox}%
+\@initializebox{\makeheaddetailstempbox}%
+\@initializelength{\makeheaddetailswidth}%
+\@initializelength{\makeheaddetailsboxwidth}%
+\@initializelength{\makecvheadnamewidth}% optional makecvheadname width to force a certain width (if set/remains to 0pt, the width is calculated automatically)
+\@initializeif{\if@firstmakeheaddetailselement}\@firstmakeheaddetailselementtrue%
+%   adds an element to the makehead, separated by makeheadsymbol
+%   usage: \addtomakehead[makeheadsymbol]{element}
+\newcommand*{\addtomakeheaddetails}[2][\makeheaddetailssymbol]{% TODO: use \@initializecommand, which requires modifying its definition to handle mandatory and optional arguments
+  \if@firstmakeheaddetailselement%
+  \savebox{\makeheaddetailstempbox}{\usebox{\makeheaddetailsbox}#2}%
+  \else%
+  \savebox{\makeheaddetailstempbox}{\usebox{\makeheaddetailsbox}#1#2}\fi%
+  \settowidth{\makeheaddetailsboxwidth}{\usebox{\makeheaddetailstempbox}}%
+  \ifnum\makeheaddetailsboxwidth<\makeheaddetailswidth%
+  \savebox{\makeheaddetailsbox}{\usebox{\makeheaddetailstempbox}}%
+  \@firstmakeheaddetailselementfalse%
+  \else%
+  \flushmakeheaddetails\\%
+  \savebox{\makeheaddetailsbox}{#2}%
+  \savebox{\makeheaddetailstempbox}{#2}%
+  \settowidth{\makeheaddetailsboxwidth}{\usebox{\makeheaddetailsbox}}%
+  \@firstmakeheaddetailselementfalse\fi}
+% internal command to flush the makehead
+\@initializecommand{\flushmakeheaddetails}{%
+  \strut\usebox{\makeheaddetailsbox}%
+  \savebox{\makeheaddetailsbox}{}%
+  \savebox{\makeheaddetailstempbox}{}%
+  \setlength{\makeheaddetailsboxwidth}{0pt}}
+\@initializecommand{\makehead}{%
+  \setlength{\makeheaddetailswidth}{\textwidth}%
+  \hfil%
+  \parbox{\makeheaddetailswidth}{%
+    \namestyle{\@firstname~\@lastname}%
+    \ifthenelse{\equal{\@title}{}}{}{\titlestyle{~|~\@title}}
+  }\\
+  \parbox{\makeheaddetailswidth}{%
+    \if@details{%
+      \addressfont\color{color2}%
+      \ifthenelse{\isundefined{\@addressstreet}}{}{\addtomakeheaddetails{\addresssymbol\@addressstreet}%
+        \ifthenelse{\equal{\@addresscity}{}}{}{\addtomakeheaddetails[~--~]{\@addresscity}}%
+        % if \addresstreet is defined, \addresscity and \addresscountry will always be defined but could be empty
+        \ifthenelse{\equal{\@addresscountry}{}}{}{\addtomakeheaddetails[~--~]{\@addresscountry}}%
+        \flushmakeheaddetails\@firstmakeheaddetailselementtrue}%
+    }\fi
+  }\\
+  \parbox{\makeheaddetailswidth}{%
+    \if@details{%
+      \addressfont\color{color2}%
+      \collectionloop{phones}{% the key holds the phone type (=symbol command prefix), the item holds the number
+        \addtomakeheaddetails{\csname\collectionloopkey phonesymbol\endcsname\collectionloopitem}}%
+      \ifthenelse{\isundefined{\@email}}{}{\addtomakeheaddetails{\emailsymbol\emaillink{\@email}}}%
+      \flushmakeheaddetails
+    }\fi
+  }\\
+  \parbox{\makeheaddetailswidth}{%
+    \if@details{%
+      \addressfont\color{color2}%
+      \collectionloop{socials}{% the key holds the social type (=symbol command prefix), the item holds the link\newline
+        \addtomakeheaddetails{\csname\collectionloopkey
+          socialsymbol\endcsname\collectionloopitem}}%
+      \flushmakeheaddetails
+    }\fi
+  }\\
+  \parbox{\makeheaddetailswidth}{%
+    \if@details{%
+      \addressfont\color{color2}%
+      \ifthenelse{\isundefined{\@homepage}}{}%
+      {\addtomakeheaddetails{\makenewline\homepagesymbol\httplink[\@homepage]{\@homepage}}}%
+      \ifthenelse{\isundefined{\@extrainfo}}{}{\addtomakeheaddetails{\@extrainfo}}%
+      \flushmakeheaddetails
+    }\fi
+  }\\%[2.5em]
+}% need to force a \par after this to avoid weird spacing bug at the first section if no blank line is left after \makehead
+
+%-------------------------------------------------------------------------------
+%                resume head definition
+%-------------------------------------------------------------------------------
+% lengths
+\@initializelength{\quotewidth}
+\renewcommand*{\recomputecvheadlengths}{%
+  \setlength{\quotewidth}{0.65\textwidth}}
+
+% commands
+\renewcommand*{\makecvhead}{% TODO: use \@initializecommand, which requires modifying its definition to handle \par
+  % recompute lengths (in case we are switching from letter to resume, or vice versa)
+  \recomputecvlengths%
+  % optional picture box
+  \newbox{\makecvheadpicturebox}%
+  \savebox{\makecvheadpicturebox}{%
+    \ifthenelse{\isundefined{\@photo}}%
+    {}%
+    {%
+      \color{color1}%
+      \setlength\fboxrule{\@photoframewidth}%
+      \ifdim\@photoframewidth=0pt%
+      \setlength{\fboxsep}{0pt}\fi%
+      \framebox{\includegraphics[width=\@photowidth]{\@photo}}}}%
+  \newlength{\makecvheadpicturewidth}\settowidth{\makecvheadpicturewidth}{\usebox{\makecvheadpicturebox}}%
+  \ifthenelse{\lengthtest{\makecvheadnamewidth=0pt}}% check for dummy value (equivalent to \ifdim\makecvheadnamewidth=0pt)
+  {\setlength{\makecvheadnamewidth}{\textwidth-\makecvheadpicturewidth}}%
+  {}%
+  \begin{minipage}[t]{\textwidth}
+    \begin{minipage}[b]{\makecvheadpicturewidth}
+      % optional photo
+      \usebox{\makecvheadpicturebox}%
+    \end{minipage}
+    \hspace{1em}
+    \begin{minipage}[b]{\makecvheadnamewidth}%
+      \makehead%
+    \end{minipage}\\%[2.5em]%
+  \end{minipage}
+  % optional quote
+  \ifthenelse{\isundefined{\@quote}}%
+  {}%
+  {{\centering\begin{minipage}{\quotewidth}\centering\quotestyle{\@quote}\end{minipage}\\[2.5em]}}%
+  \par}% to avoid weird spacing bug at the first section if no blank line is left after \maketitle}
+
+%-------------------------------------------------------------------------------
+%                letter head definition
+%-------------------------------------------------------------------------------
+% lengths
+%\renewcommand*{\recomputeletterheadlengths}{}
+
+% commands
+\renewcommand*{\makeletterhead}{%
+  % recompute lengths (in case we are switching from letter to resume, or vice versa)
+  \recomputeletterlengths%
+  % sender block
+  \makehead%
+  \par%
+   % recipient block
+  \begin{minipage}[t]{.5\textwidth}
+    \raggedright%
+    \addressfont%
+    {\bfseries\upshape\@recipientname}\\%
+    \@recipientaddress%
+  \end{minipage}
+  % date
+  \hfill% US style
+%  \\[1em]% UK style
+  \@date\\[2em]% US informal style: "January 1, 1900"; UK formal style: "01/01/1900"
+  % opening
+  \raggedright%
+  \@opening\\[1.5em]%
+  % ensure no extra spacing after \makelettertitle due to a possible blank line
+%  \ignorespacesafterend% not working
+  \hspace{0pt}\par\vspace{-\baselineskip}\vspace{-\parskip}}
+
+
+\endinput
+
+
+%% end of file `moderncvheadiii.sty'.

--- a/moderncvstylebankingplus.sty
+++ b/moderncvstylebankingplus.sty
@@ -1,0 +1,65 @@
+%% start of file `moderncvstylebankingplus.sty'.
+%% Copyright 2006-2015 Xavier Danaux (xdanaux@gmail.com).
+%% Modification Copyright 2019-2019 Raju Rimal (therimalaya@gmail.com).
+%
+% This work may be distributed and/or modified under the
+% conditions of the LaTeX Project Public License version 1.3c,
+% available at http://www.latex-project.org/lppl/.
+
+
+%-------------------------------------------------------------------------------
+%                identification
+%-------------------------------------------------------------------------------
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{moderncvstylebankingplus}[2019/10/30 v2.0.0 modern curriculum vitae and letter style scheme: bankingplus]
+
+% body rules type options: "fullrules", "shortrules", "mixedrules" (default) or "norules"
+\@initializecommand{\moderncvstylebodyoptions}{}
+\DeclareOption{fullrules}    {\edef\moderncvstylebodyoptions{\moderncvstylebodyoptions,fullrules}}
+\DeclareOption{shortrules}   {\edef\moderncvstylebodyoptions{\moderncvstylebodyoptions,shortrules}}
+\DeclareOption{mixedrules}   {\edef\moderncvstylebodyoptions{\moderncvstylebodyoptions,mixedrules}}
+\DeclareOption{norules}      {\edef\moderncvstylebodyoptions{\moderncvstylebodyoptions,norules}}
+
+% body section alignment options: "left" (default), "center" or "right"
+\DeclareOption{left}         {\edef\moderncvstylebodyoptions{\moderncvstylebodyoptions,left}}
+\DeclareOption{center}       {\edef\moderncvstylebodyoptions{\moderncvstylebodyoptions,center}}
+\DeclareOption{right}        {\edef\moderncvstylebodyoptions{\moderncvstylebodyoptions,right}}
+
+\DeclareOption*{}% avoid choking on unknown options
+\ExecuteOptions{mixedrules,left}
+\ProcessOptions*\relax% \ProcessOptions* processes the options in the order provided (i.e., with the later ones possibly overriding the former ones), while \ProcessOptions processes them in the order of the package
+
+
+%-------------------------------------------------------------------------------
+%                fonts & icons
+%-------------------------------------------------------------------------------
+% TeX Gyre Pagella font
+%\ifxetexorluatex
+%  \setmainfont{Tex-Gyre Pagella}
+%  \setsansfont{Tex-Gyre Pagella}
+%  \setmathfont{Tex-Gyre Pagella}
+%  \setmathfont[range=\mathit,\mathsfit]{Tex-Gyre Pagella Italic}
+%  \setmathfont[range=\mathbfup,\mathbfsfup]{Tex-Gyre Pagella Bold}
+%  \setmathfont[range=\mathbfit,\mathbfsfit]{Tex-Gyre Pagella Bold Italic}
+%\else
+  \IfFileExists{tgpagella.sty}%
+    {%
+      \RequirePackage{tgpagella}%
+      \renewcommand*{\familydefault}{\rmdefault}}%
+    {}
+%\fi
+
+% symbols
+\moderncvicons{awesome}
+
+
+%-------------------------------------------------------------------------------
+%                header, body & footer
+%-------------------------------------------------------------------------------
+\moderncvhead{7}
+\moderncvbody[\moderncvstylebodyoptions]{7}
+
+\endinput
+
+
+%% end of file `moderncvstylebankingplus.sty'.


### PR DESCRIPTION
## Change log

1. A style `bankingplus` is added which allows users to include photos in the `banking` style cv. The header is not centred but is left-aligned to match with the photo at the top-left corner.
2. The command `cventry` always leave blank like if second-fifth arguments are not available. However, In many cases, multiple post or projects can be included when working at the same institution. In order to have this nested structure, two new commands `cventryout` and `cventryin` are added which are just a smaller version of `cventry` with only 4 options.

Following is an example that I have created using the changes:

### BankingPlus Header Style
![image](https://user-images.githubusercontent.com/675384/67846558-b4e5aa00-fb01-11e9-86cc-04517a8721ec.png)

### CV Entry with Nested items without any blank line
![image](https://user-images.githubusercontent.com/675384/67846601-ca5ad400-fb01-11e9-920c-9f52fde04cf9.png)
