### PR TITLE
Feature/GitHub action for building example "template" 

### DIFF
--- a/.github/workflows/template-example.yml
+++ b/.github/workflows/template-example.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    name: GenerateCvExamples
+    runs-on: ubuntu-latest
+    container: blang/latex:ctanfull
+    steps:
+    - run:  pdflatex examples/template.tex
+    - uses: actions/upload-artifact@v1
+      with:
+        name: template_example
+        path: examples/template.pdf

--- a/.github/workflows/template-example.yml
+++ b/.github/workflows/template-example.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - run:  pdflatex examples/template.tex
+    - run:  cd examples && pdflatex template.tex
     - uses: actions/upload-artifact@v1
       with:
         name: template_example

--- a/.github/workflows/template-example.yml
+++ b/.github/workflows/template-example.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     container: blang/latex:ctanfull
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
     - run:  pdflatex examples/template.tex
     - uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
Hi, 

here is a simple github action which runs pdf latex in a build step inside the  blang/latex:ctanfull image (docs: https://github.com/blang/latex-docker). At the end the generated PDF is available for download.

Since I am no real Latex hero, I am not sure if thats the correct image, but that can be adjusted.

Currently, only the "template.tex" out of the examples is compiled and the pipeline shall be good enough to test and validate pullrequests.

Users then can easily fork your repo or use the examples together with this github actions pipeline to create the pdf automatically with each git push.

Here is the link to an example run: https://github.com/cpolzer/moderncv/actions/runs/34389530

Thanks for the great work and regards! 