### PR TITLE
Update moderncv.cls

### DIFF
--- a/moderncv.cls
+++ b/moderncv.cls
@@ -191,7 +191,7 @@
 % compatibility package with older versions of moderncv
 \RequirePackageWithOptions{moderncvcompatibility}
 
-\RequirePackage{l3regex}
+\RequirePackage{expl3}
 
 %-------------------------------------------------------------------------------
 %                class definition


### PR DESCRIPTION
l3regex has been absorbed into expl3 now. 
If using Overleaf the current gives an error of not finding l3regex.sty which is fixed by replacing with expl3
P.S. I love this project :+1: